### PR TITLE
Focus Cards responsiveness

### DIFF
--- a/src/components/FocusCard.jsx
+++ b/src/components/FocusCard.jsx
@@ -2,19 +2,23 @@
 import React from "react";
 
 const FocusCard = ({ name, text, icon, bgColor }) => {
+  // note: !pr-0 is to allow the underline to fully extend to the right,
+  // `sm:pr-8 md:pr-4 lg:pr-8` should be applied to any element that isn't the underline
   return (
     <div
-      className={`flex flex-col justify-between aspect-square text-white ${bgColor} w-full sm:p-3 md:p-1 lg:p-3`}
+      className={`flex flex-col justify-betweenaspect-square text-white ${bgColor} w-full !pr-0 sm:p-8 md:p-4 lg:p-8 gap-16`}
     >
-      <div className="flex justify-between">
-        <div className="ml-4 mt-1">{icon}</div>
+      <div className="flex justify-between items-start">
+        <div>{icon}</div>
 
-        <div className="mt-2 mr-4 justify-end underline decoration-4 text-2xl md:text-lg lg:text-2xl font-bold">
+        <div className="border-b-4 border-white justify-end text-2xl md:text-lg lg:text-2xl leading-none font-bold flex items-end sm:pr-8 md:pr-4 lg:pr-8 pl-4">
           {name}
         </div>
       </div>
 
-      <div className="mb-3 ml-5 text-xl md:text-base lg:text-xl">{text}</div>
+      <div className="text-xl md:text-base lg:text-xl sm:pr-8 md:pr-4 lg:pr-8">
+        {text}
+      </div>
     </div>
   );
 };

--- a/src/components/FocusCard.jsx
+++ b/src/components/FocusCard.jsx
@@ -4,17 +4,17 @@ import React from "react";
 const FocusCard = ({ name, text, icon, bgColor }) => {
   return (
     <div
-      className={`flex flex-col justify-between aspect-square text-white ${bgColor} w-full p-3`}
+      className={`flex flex-col justify-between aspect-square text-white ${bgColor} w-full sm:p-3 md:p-1 lg:p-3`}
     >
       <div className="flex justify-between">
         <div className="ml-4 mt-1">{icon}</div>
 
-        <div className="mt-2 mr-4 justify-end underline decoration-4 text-2xl font-bold">
+        <div className="mt-2 mr-4 justify-end underline decoration-4 text-2xl md:text-lg lg:text-2xl font-bold">
           {name}
         </div>
       </div>
 
-      <div className="mb-3 ml-5 text-xl">{text}</div>
+      <div className="mb-3 ml-5 text-xl md:text-base lg:text-xl">{text}</div>
     </div>
   );
 };

--- a/src/components/FocusCards.jsx
+++ b/src/components/FocusCards.jsx
@@ -26,7 +26,7 @@ const cardList = [
 ];
 const FocusCards = () => {
   return (
-    <Row className="w-2/3 my-12 font-poppins">
+    <Row className="p-4 w-full 2xl:p-0 2xl:w-2/3 my-12 font-poppins">
       {cardList.map((card, index) => (
         <Col xs={12} md={4} className="p-3" key={index}>
           <FocusCard

--- a/src/components/FocusCards.jsx
+++ b/src/components/FocusCards.jsx
@@ -26,7 +26,7 @@ const cardList = [
 ];
 const FocusCards = () => {
   return (
-    <Row className="w-2/3 my-12">
+    <Row className="w-2/3 my-12 font-poppins">
       {cardList.map((card, index) => (
         <Col xs={12} md={4} className="p-3" key={index}>
           <FocusCard

--- a/src/components/FocusCards.jsx
+++ b/src/components/FocusCards.jsx
@@ -26,9 +26,9 @@ const cardList = [
 ];
 const FocusCards = () => {
   return (
-    <Row className="p-4 w-full 2xl:p-0 2xl:w-2/3 my-12 font-poppins">
+    <Row className="sm:p-4 md:p-3 lg:p-4 w-full 2xl:p-0 2xl:w-2/3 my-12 font-poppins">
       {cardList.map((card, index) => (
-        <Col xs={12} md={4} className="p-3" key={index}>
+        <Col xs={12} md={4} className="sm:p-3 md:p-2 lg:p-3" key={index}>
           <FocusCard
             name={card.name}
             text={card.text}


### PR DESCRIPTION
closes #51 

margins were reduced since there isn't enough space to fix the horizontal paddings, margins, and also the text "Professional" (realllylyyy long word)

sm-md threshold
![image](https://github.com/acm-ucr/asme-website/assets/12877445/9a250198-f118-4ba8-aee8-444be62705d0)

md
![image](https://github.com/acm-ucr/asme-website/assets/12877445/742fad88-ec8a-4c97-b729-44aca0e1a5ac)

lg
![image](https://github.com/acm-ucr/asme-website/assets/12877445/5236f78c-aa89-4965-852a-24cfa175182d)

2xl
![image](https://github.com/acm-ucr/asme-website/assets/12877445/0dd26bba-2073-4d5b-bcc6-3caf98a8c9a7)
