### PR TITLE
responsive /about pictures

### DIFF
--- a/src/components/AboutSection.jsx
+++ b/src/components/AboutSection.jsx
@@ -30,9 +30,16 @@ const AboutSection = () => {
               sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
           </div>
-          <div className="flex flex-row 2-full justify-center gap-4">
-            <Image src={ASME1} />
-            <Image src={ASME2} />
+          <div className="flex flex-wrap w-full justify-center gap-4 p-8">
+            {[ASME1, ASME2].map((src, index) => (
+              <Image
+                src={src}
+                key={index}
+                sizes="(max-width: 768px) 80vw,
+                  50%"
+                className="max-w-lg"
+              />
+            ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
closes #67 

using flex-wrap instead to handle responsiveness, added some form of image resizing to prevent overflow issues

![image](https://github.com/acm-ucr/asme-website/assets/12877445/d2e8e07e-f084-4a5c-8240-aa7963b24498)
![image](https://github.com/acm-ucr/asme-website/assets/12877445/765dcc91-e42b-4f68-b2aa-2f09e49d98d3)
