### PR TITLE
joincard onhover is now readable

### DIFF
--- a/src/components/home/JoinCard.jsx
+++ b/src/components/home/JoinCard.jsx
@@ -1,6 +1,14 @@
 import React from "react";
 import Link from "next/link";
 
+// probably improper use of tailwind, but doing otherwise would require changing project with color management and usage of style, maybe bg-clip-text could work but that's hard
+const HOVER_CLASS_MAPPING = {
+  "bg-asme-blue-600": "hover:!text-asme-blue-600",
+  "bg-asme-blue-500": "hover:!text-asme-blue-500",
+  "bg-asme-blue-400": "hover:!text-asme-blue-400",
+  "bg-asme-blue-300": "hover:!text-asme-blue-300",
+};
+
 const JoinCard = ({ text, icon, link, bgColor }) => {
   return (
     <div
@@ -12,7 +20,7 @@ const JoinCard = ({ text, icon, link, bgColor }) => {
       </p>
       <Link
         href={link}
-        className={`text-white ${bgColor} border-white border-2 py-1 px-4 hover:bg-white hover:text-asme-blue-600 font-poppins font-semibold w-3/5 no-underline text-center`}
+        className={`text-white ${bgColor} border-white border-2 py-1 px-4 hover:bg-white ${HOVER_CLASS_MAPPING[bgColor]} font-poppins font-semibold w-3/5 no-underline text-center`}
       >
         Join
       </Link>


### PR DESCRIPTION

![image](https://github.com/acm-ucr/asme-website/assets/12877445/dbdbfd05-477f-48a7-9599-88472ff17607)

fixes #61 