### PR TITLE
staggered events (based on scroll)

### DIFF
--- a/src/components/events/EventDescriptions.jsx
+++ b/src/components/events/EventDescriptions.jsx
@@ -1,4 +1,7 @@
+"use client";
+
 import React from "react";
+import { motion } from "framer-motion";
 import EventDescription from "./EventDescription";
 import UpcomingEvents from "./UpcomingEvents";
 
@@ -45,11 +48,20 @@ const EventDescriptions = () => {
   return (
     <div className="w-full flex-col flex">
       <UpcomingEvents />
-      <div className="self-center w-9/12">
+      <motion.div className="self-center w-9/12">
         {Events.map((event, index) => {
-          return <EventDescription key={index} event={event} />;
+          return (
+            <motion.div
+              initial={{ x: 8, opacity: 0 }}
+              whileInView={{ x: 0, opacity: 1 }}
+              transition={{ duration: 0.5, ease: "easeOut" }}
+              key={index}
+            >
+              <EventDescription event={event} />
+            </motion.div>
+          );
         })}
-      </div>
+      </motion.div>
     </div>
   );
 };


### PR DESCRIPTION
fixes #91 ; kinda, if you scroll normally they'll be staggered (since its based on "entering viewport"), but if you teleport to the middle, they'll show up together. i wasn't able to figure out how to use `staggerChildren` along with `whileInView`.

https://github.com/acm-ucr/asme-website/assets/12877445/f0b8e1a2-ab25-4121-857b-d255d6448394

