### PR TITLE
removal of 'use client' and moving 'use client' into children modules…

### DIFF
--- a/src/components/events/EventDescriptions.jsx
+++ b/src/components/events/EventDescriptions.jsx
@@ -1,4 +1,4 @@
-"use client";
+// "use client"; // might be needed; but can only be tested after event fetching works
 
 import React from "react";
 import { motion } from "framer-motion";

--- a/src/components/events/EventDescriptions.jsx
+++ b/src/components/events/EventDescriptions.jsx
@@ -1,4 +1,4 @@
-// "use client"; // might be needed; but can only be tested after event fetching works
+"use client"; // probably is needed, runtime explodes when you don't "use client"
 
 import React from "react";
 import { motion } from "framer-motion";

--- a/src/components/home/FocusCards.jsx
+++ b/src/components/home/FocusCards.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Row, Col } from "react-bootstrap";
 import FocusCard from "./FocusCard";

--- a/src/components/home/JoinCards.jsx
+++ b/src/components/home/JoinCards.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { joinList } from "@/data/joinCards";
 import JoinCard from "./JoinCard";

--- a/src/components/home/JoinUsSection.jsx
+++ b/src/components/home/JoinUsSection.jsx
@@ -1,4 +1,3 @@
-"use client";
 import React from "react";
 import JoinCards from "./JoinCards.jsx";
 

--- a/src/components/home/WhatWeDoSection.jsx
+++ b/src/components/home/WhatWeDoSection.jsx
@@ -1,4 +1,3 @@
-"use client";
 import React from "react";
 import FocusCards from "./FocusCards";
 import WhatWeDoTitle from "./WhatWeDoTitle";


### PR DESCRIPTION
fixes #128 

`'use client';` is needed in elements that
- have `useState`
- have `Row`/`Col` from `react-bootstrap` since those use `ThemeProvider` and that uses `createContext`